### PR TITLE
add feature to ignore buffers

### DIFF
--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -54,7 +54,7 @@ for option, default_value in settings.items():
     if not weechat.config_is_set_plugin(option):
         weechat.config_set_plugin(option, default_value)
 
-    if weechat.config_get_plugin(option) == "":
+    if option in required_settings and weechat.config_get_plugin(option) == "":
         weechat.prnt("", weechat.prefix("error") + "irssinotifier: Please set option: %s" % option)
         weechat.prnt("", "irssinotifier: /set plugins.var.python.irssinotifier.%s STRING" % option)
 


### PR DESCRIPTION
With the new setting "ignore" it is possible to specify a list of buffers which should be ignored on highlights.
I use this for my bitlbee-buffers to avoid double notifications (twitter-app and #twitter_prauscher)
