### PR TITLE
Support ignored servers, update API for weechat >= 1.0

### DIFF
--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -70,7 +70,7 @@ def notify_show(data, bufferp, uber_empty, tagsn, isdisplayed,
 
     #are we away?
     away = weechat.buffer_get_string(bufferp,"localvar_away")
-    if (away == "") (and weechat.config_get_plugin("only_away") == "on"):
+    if (away == "" and weechat.config_get_plugin("only_away") == "on"):
         return weechat.WEECHAT_RC_OK
         
     #get local nick for buffer

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -17,6 +17,8 @@
 # Requires Weechat >= 0.3.7, openssl
 # Released under GNU GPL v3
 #
+# 2013-08-16, kang@insecure.ws
+#     version 0.6: - only_away option (only notify if set away)
 # 2013-01-18, ccm <ccm@screenage.de>:
 #     version 0.5: - removed version check and legacy curl usage
 # 2012-12-27, ccm <ccm@screenage.de>:
@@ -44,7 +46,8 @@ weechat.register("irssinotifier", "Caspar Clemens Mierau <ccm@screenage.de>", "0
 
 settings = {
     "api_token": "",
-    "encryption_password": ""
+    "encryption_password": "",
+    "only_away": "",
 }
 
 for option, default_value in settings.items():
@@ -59,6 +62,11 @@ weechat.hook_print("", "irc_privmsg", "", 1, "notify_show", "")
 def notify_show(data, bufferp, uber_empty, tagsn, isdisplayed,
         ishilight, prefix, message):
 
+    #are we away?
+    away = weechat.buffer_get_string(bufferp,"localvar_away")
+    if (away == "") (and weechat.config_get_plugin("only_away") == "on"):
+        return weechat.WEECHAT_RC_OK
+        
     #get local nick for buffer
     mynick = weechat.buffer_get_string(bufferp,"localvar_nick")
 

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -76,7 +76,9 @@ def notify_show(data, bufferp, uber_empty, tagsn, isdisplayed,
 def encrypt(text):
     encryption_password = weechat.config_get_plugin("encryption_password")
     command="openssl enc -aes-128-cbc -salt -base64 -A -pass env:OpenSSLEncPW"
-    output,errors = Popen(shlex.split(command),stdin=PIPE,stdout=PIPE,stderr=PIPE,env={"OpenSSLEncPW": encryption_password}).communicate(text+" ")
+    opensslenv = os.environ.copy();
+    opensslenv['OpenSSLEncPW'] = encryption_password
+    output,errors = Popen(shlex.split(command),stdin=PIPE,stdout=PIPE,stderr=PIPE,env=opensslenv).communicate(text+" ")
     output = string.replace(output,"/","_")
     output = string.replace(output,"+","-")
     output = string.replace(output,"=","")

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -17,6 +17,8 @@
 # Requires Weechat >= 0.3.7, openssl
 # Released under GNU GPL v3
 #
+# 2013-08-20, balu
+#     version 0.6.1: - support for every private notification not only irc (especialy also jabber)
 # 2013-08-16, kang@insecure.ws
 #     version 0.6: - only_away option (only notify if set away)
 # 2013-01-18, ccm <ccm@screenage.de>:
@@ -62,7 +64,8 @@ for option, default_value in settings.items():
         weechat.prnt("", "irssinotifier: /set plugins.var.python.irssinotifier.%s STRING" % option)
 
 # Hook privmsg/hilights
-weechat.hook_print("", "irc_privmsg", "", 1, "notify_show", "")
+#weechat.hook_print("", "irc_privmsg", "", 1, "notify_show", "")
+weechat.hook_print("", "notify_private", "", 1, "notify_show", "")
 
 # Functions
 def notify_show(data, bufferp, uber_empty, tagsn, isdisplayed,

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -54,7 +54,7 @@ for option, default_value in settings.items():
     if not weechat.config_is_set_plugin(option):
         weechat.config_set_plugin(option, default_value)
 
-    if weechat.config_get_plugin(option) == "":
+    if option in required_settings and weechat.config_get_plugin(option) == "":
         weechat.prnt("", weechat.prefix("error") + "irssinotifier: Please set option: %s" % option)
         weechat.prnt("", "irssinotifier: /set plugins.var.python.irssinotifier.%s STRING" % option)
 

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -17,6 +17,8 @@
 # Requires Weechat >= 0.3.7, openssl
 # Released under GNU GPL v3
 #
+# 2015-02-07, zigdon
+#     version 0.6.3: - fix channel highlits in weechat >= 1.0
 # 2013-12-07, zigdon
 #     version 0.6.2: - support ignoring all buffers in a server, add help text.
 # 2013-08-20, balu
@@ -48,7 +50,7 @@ from subprocess import Popen, PIPE
 
 weechat.register("irssinotifier",
                  "Caspar Clemens Mierau <ccm@screenage.de>",
-                 "0.6.2",
+                 "0.6.3",
                  "GPL3",
                  "irssinotifier: Send push notifications to Android's IrssiNotifier about your private message and highligts.",
                  "",
@@ -101,14 +103,14 @@ def notify_show(data, bufferp, uber_empty, tagsn, isdisplayed,
     channel = weechat.buffer_get_string(bufferp, "localvar_channel")
 
     # ignore buffers on ignorelists
-    if not (server in weechat.config_get_plugin("ignore_servers") or
+    if not (server in weechat.config_get_plugin("ignore_servers").split(",") or
         name in weechat.config_get_plugin("ignore_buffers").split(",")):
 
         # only notify if the message was not sent by myself
         if (weechat.buffer_get_string(bufferp, "localvar_type") == "private") and (prefix!=mynick):
             show_notification(channel, prefix, message)
 
-        elif ishilight == "1":
+        elif ishilight:
             buffer = (weechat.buffer_get_string(bufferp, "short_name") or name)
             show_notification(buffer, prefix, message)
 

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -75,19 +75,24 @@ for option, help_text in settings.items():
     weechat.config_set_desc_plugin(option, help_text)
 
 # Hook privmsg/hilights
-weechat.hook_print("", "irc_privmsg", "", 1, "notify_show", "")
+weechat.hook_print("", "notify_message", "", 1, "notify_show", "")
 weechat.hook_print("", "notify_private", "", 1, "notify_show", "")
 
 # Functions
 def notify_show(data, bufferp, uber_empty, tagsn, isdisplayed,
         ishilight, prefix, message):
 
-    #are we away?
+    # irc PMs are caught by notify_private, but we need notify_message to
+    # capture hilights in channels.
+    if 'notify_message' in tagsn and not ishilight:
+        return weechat.WEECHAT_RC_OK
+
+    # are we away?
     away = weechat.buffer_get_string(bufferp,"localvar_away")
     if (away == "" and weechat.config_get_plugin("only_away") == "on"):
         return weechat.WEECHAT_RC_OK
 
-    #get local nick for buffer
+    # get local nick for buffer
     mynick = weechat.buffer_get_string(bufferp,"localvar_nick")
 
     # get buffer info

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -75,8 +75,8 @@ def notify_show(data, bufferp, uber_empty, tagsn, isdisplayed,
 
 def encrypt(text):
     encryption_password = weechat.config_get_plugin("encryption_password")
-    command="openssl enc -aes-128-cbc -salt -base64 -A -pass pass:%s" % (encryption_password)
-    output,errors = Popen(shlex.split(command),stdin=PIPE,stdout=PIPE,stderr=PIPE).communicate(text+" ")
+    command="openssl enc -aes-128-cbc -salt -base64 -A -pass env:OpenSSLEncPW"
+    output,errors = Popen(shlex.split(command),stdin=PIPE,stdout=PIPE,stderr=PIPE,env={"OpenSSLEncPW": encryption_password}).communicate(text+" ")
     output = string.replace(output,"/","_")
     output = string.replace(output,"+","-")
     output = string.replace(output,"=","")

--- a/irssinotifier.py
+++ b/irssinotifier.py
@@ -64,7 +64,7 @@ for option, default_value in settings.items():
         weechat.prnt("", "irssinotifier: /set plugins.var.python.irssinotifier.%s STRING" % option)
 
 # Hook privmsg/hilights
-#weechat.hook_print("", "irc_privmsg", "", 1, "notify_show", "")
+weechat.hook_print("", "irc_privmsg", "", 1, "notify_show", "")
 weechat.hook_print("", "notify_private", "", 1, "notify_show", "")
 
 # Functions


### PR DESCRIPTION
- Add setting help messages
- Add setting to ignore all highlights from a list of servers
- Fix double highlights on PMs
- Update API so that channel highlights work with weechat >= 1.0
